### PR TITLE
Update boost_remaining unit from minutes to min.

### DIFF
--- a/custom_components/helios_vallox_ventilation/vent_conf.yaml
+++ b/custom_components/helios_vallox_ventilation/vent_conf.yaml
@@ -98,7 +98,7 @@
     - name: "boost_remaining"
       device_class: "duration"
       state_class: "measurement"
-      unit_of_measurement: "minutes"
+      unit_of_measurement: "min"
       icon: "mdi:fan-clock"
     
     - name: "input_fan_percent"


### PR DESCRIPTION
This fixes the log-message:
Entity sensor.ventilation_boost_remaining is using native unit of measurement 'minutes' which is not a valid unit for the device class ('duration') it is using; expected one of ['ms', 'd', 'μs', 'h', 'min', 's']